### PR TITLE
battle view ui and moves api integration.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
+import BattleView from "./pages/BattleView";
 
 const App = () => (
   <Router>
     <Routes>
       <Route path="/" element={<Home />} />
+      <Route path="/battle" element={<BattleView />} /> 
     </Routes>
   </Router>
 );

--- a/src/api/pokemonApi.ts
+++ b/src/api/pokemonApi.ts
@@ -2,13 +2,14 @@ import axios from "axios";
 import { Pokemon, PokemonMove } from "../types";
 
 const POKE_API_BASE_URL = "https://pokeapi.co/api/v2/pokemon";
+const MOVE_API_BASE_URL = "https://pokeapi.co/api/v2/move";
 
 // tried to get pokemon names dynamically from the api response as the given api is specifically paginated 
 export const getAvailablePokemonList = async (limit: number = 20): Promise<string[]> => {
   try {
     const { data } = await axios.get<{ results: { name: string }[] }>(`${POKE_API_BASE_URL}?limit=${limit}`);
 
-    return data.results.map(pokemon => pokemon.name); 
+    return data.results.map(pokemon => pokemon.name);
   } catch (error) {
     console.error("Error fetching available Pokémon list:", error);
     return [];
@@ -26,13 +27,24 @@ export const getPokemon = async (name: string): Promise<Pokemon | null> => {
         front_default: data.sprites.front_default,
         back_default: data.sprites.back_default,
       },
-      stats: data.stats, 
-      types: data.types, 
+      stats: data.stats,
+      types: data.types,
       moves: extractMoves(data.moves),
     };
   } catch (error) {
     console.error(`Error fetching Pokémon with name ${name}:`, error);
     return null;
+  }
+};
+
+export const getMoveDetails = async (moveName: string): Promise<PokemonMove> => {
+  try {
+    const { data } = await axios.get<{ power: number }>(`${MOVE_API_BASE_URL}/${moveName}`);
+
+    return { move: { name: moveName }, power: data.power || 0 }; // default to 0 if power is null from the move api response 
+  } catch (error) {
+    console.error(`Error fetching move ${moveName}:`, error);
+    return { move: { name: moveName }, power: 0 };
   }
 };
 

--- a/src/pages/BattleView.tsx
+++ b/src/pages/BattleView.tsx
@@ -1,0 +1,87 @@
+import { useDispatch, useSelector } from "react-redux";
+import { startBattle } from "../store/battleSlice";
+import { RootState, AppDispatch } from "../store";
+import { useMemo } from "react";
+
+const BattleView = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const { pokemon1, pokemon2, selectedMoves, battleLog } = useSelector((state: RootState) => state.battle);
+
+  // useMemo to prevent unnecessary calculations
+  const move1 = useMemo(() => {
+    if (pokemon1?.name && selectedMoves[pokemon1.name]) {
+      return selectedMoves[pokemon1.name];
+    }
+    return null; 
+  }, [pokemon1, selectedMoves]);
+
+  const move2 = useMemo(() => {
+    if (pokemon2?.name && selectedMoves[pokemon2.name]) {
+      return selectedMoves[pokemon2.name];
+    }
+    return null; 
+  }, [pokemon2, selectedMoves]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-6">
+      <div className="border border-gray-300 bg-white rounded-lg p-6 shadow-lg w-full max-w-2xl relative">
+        
+        <div className="flex flex-col space-y-6 px-4 py-6 border border-gray-300">
+          {pokemon1 && (
+            <div className="flex items-center justify-end">
+            <div className="relative flex items-center border border-gray-400 rounded-lg px-4 py-2">
+              <strong className="text-lg font-semibold">{pokemon1.name}</strong>
+              {move1 ? (
+                <div className="ml-3 bg-blue-200 text-blue-800 text-sm px-3 py-1 rounded-full">
+                  {move1.move.name}: {move1.power}
+                </div>
+              ) : (
+                <div className="ml-3 bg-red-200 text-red-800 text-sm px-3 py-1 rounded-full">Move not found</div>
+              )}
+            </div>
+            <span className="text-gray-500">{">"}</span>
+            <img src={pokemon1.sprites.front_default} alt={pokemon1.name || "Pokémon"} className="w-40 h-40" />
+          </div>
+          )}
+
+          {pokemon2 && (
+              <div className="flex items-center">
+              <img src={pokemon2.sprites.back_default} alt={pokemon2.name || "Pokémon"} className="w-40 h-40" />
+              <span className=" text-gray-500">{"<"}</span>
+              <div className="relative flex items-center border border-gray-400 rounded-lg px-4 py-2">
+                <strong className="text-lg font-semibold">{pokemon2.name}</strong>
+                {move2 ? (
+                  <div className="ml-3 bg-green-200 text-green-800 text-sm px-3 py-1 rounded-full">
+                    {move2.move.name}: {move2.power}
+                  </div>
+                ) : (
+                  <div className="ml-3 bg-red-200 text-red-800 text-sm px-3 py-1 rounded-full">Move not found</div>
+                )}
+                
+              </div>
+            </div>
+            
+          )}
+        </div>
+
+        <div className="border border-gray-300 mt-4 px-4 py-6">
+          <h3 className="text-lg font-semibold mb-2">Battle Log</h3>
+          <div className="bg-gray-100 p-4 rounded-lg min-h-[50px] text-gray-700">
+            {battleLog || "Click 'Start Battle' to begin!"}
+          </div>
+        </div>
+
+        <div className="flex justify-end mt-4">
+          <button
+            onClick={() => dispatch(startBattle())}
+            className="px-4 py-2 bg-blue-600 text-white font-bold rounded-lg hover:bg-blue-700 transition"
+          >
+            Start Battle!
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BattleView;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,14 +5,15 @@ import { useDispatch } from "react-redux";
 import useFetchPokemon from "../hooks/useFetchPokemon";
 import PokemonCard from "../components/PokemonCard";
 import { fetchPokemon } from "../store/action";
+import { fetchMoveDetails, setPokemons } from "../store/battleSlice";
 import { AppDispatch } from "../store";
 
 const LoadingIndicator = () => (
-  <div className="w-full flex flex-col items-center justify-center">
-    <img src="/loading.gif" alt="Loading Pokémon..." className="w-24 h-24" loading="lazy" />
-    <p className="mt-2 text-gray-700 text-center">Fetching Pokémon… please wait.</p>
-  </div>
-);
+    <div className="w-full flex flex-col items-center justify-center">
+      <img src="/loading.gif" alt="Loading Pokémon..." className="w-24 h-24" loading="lazy" />
+      <p className="mt-2 text-gray-700 text-center">Fetching Pokemon… please wait.</p>
+    </div>
+  );
 
 const Home = () => {
   const navigate = useNavigate();
@@ -31,11 +32,26 @@ const Home = () => {
 
   const [playerOne, playerTwo] = useMemo(() => players, [players]);
 
+  const handleSelectGame = async () => {
+    if (!playerOne || !playerTwo) {
+      alert("Please select Pokémon first!");
+      return;
+    }
+
+    try {
+      dispatch(setPokemons({ pokemon1: playerOne, pokemon2: playerTwo }));
+      await dispatch(fetchMoveDetails(playerOne));
+      await dispatch(fetchMoveDetails(playerTwo));
+      navigate("/battle");
+    } catch (error) {
+      alert("Error fetching moves. Please try again.");
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-red-200 p-6">
       <h1 className="text-2xl underline font-medium mb-6 text-gray-900">Select Random Pokémon</h1>
-
-      <div
+         <div
         role="region"
         aria-live="polite"
         className="relative bg-white shadow-lg rounded-3xl p-8 flex items-center justify-between w-full max-w-3xl border border-gray-200 min-h-[350px]"
@@ -44,27 +60,27 @@ const Home = () => {
           <LoadingIndicator />
         ) : (
           <>
-            <div className="flex-1 flex flex-col items-center">
-              <PokemonCard
+          <div className="flex-1 flex flex-col items-center">
+            <PokemonCard
                 key={playerOne?.id}
                 name={playerOne?.name}
                 sprite={playerOne?.sprites?.back_default || "/placeholder.png"}
                 isLeft
-              />
-            </div>
+                />
+                </div>
             <div
-              role="img"
-              aria-label="Versus battle indicator"
-              className="text-xl font-extrabold text-gray-700 mx-6 p-4 bg-gray-200 rounded-lg shadow-md"
-            >
-              VS
-            </div>
-            <div className="flex-1 flex flex-col items-center">
-              <PokemonCard
-                key={playerTwo?.id}
-                name={playerTwo?.name}
-                sprite={playerTwo?.sprites?.front_default || "/placeholder.png"}
-              />
+            role="img"
+            aria-label="Versus battle indicator"
+            className="text-xl font-extrabold text-gray-700 mx-6 p-4 bg-gray-200 rounded-lg shadow-md"
+          >
+            VS
+          </div>
+          <div className="flex-1 flex flex-col items-center">
+            <PokemonCard
+            key={playerTwo?.id}
+            name={playerTwo?.name}
+            sprite={playerTwo?.sprites?.front_default || "/placeholder.png"}
+            />
             </div>
           </>
         )}
@@ -72,17 +88,17 @@ const Home = () => {
 
       <div className="mt-10 flex gap-10">
         <button
-          onClick={handleRefresh}
-          disabled={isFetching}
-          className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg shadow-md transition-all duration-300 disabled:bg-gray-400 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        onClick={handleRefresh} 
+        disabled={isFetching}
+        className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg shadow-md transition-all duration-300 disabled:bg-gray-400 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         >
-          {isFetching ? "Refreshing..." : "Refresh Pokémon"}
+        {isFetching ? "Refreshing..." : "Refresh Pokemon"}
         </button>
         <button
-          onClick={() => navigate("/")}
-          className="px-6 py-3 bg-green-600 hover:bg-green-700 text-white rounded-lg shadow-md transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
-        >
-          Pokémon Selected
+         onClick={handleSelectGame} 
+         className="px-6 py-3 bg-green-600 hover:bg-green-700 text-white rounded-lg shadow-md  transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+         >
+          Pokemon Selected
         </button>
       </div>
     </div>

--- a/src/store/battleSlice.ts
+++ b/src/store/battleSlice.ts
@@ -1,0 +1,79 @@
+import { createSlice, PayloadAction, createAsyncThunk } from "@reduxjs/toolkit";
+import { Pokemon, PokemonMove } from "../types";
+import { getMoveDetails } from "../api/pokemonApi";
+
+interface BattleState {
+  pokemon1?: Pokemon; 
+  pokemon2?: Pokemon;
+  selectedMoves: Record<string, PokemonMove | undefined>; 
+  battleLog: string;
+}
+
+const initialState: BattleState = {
+  selectedMoves: {}, 
+  battleLog: "",
+};
+
+export const fetchMoveDetails = createAsyncThunk(
+  "battle/fetchMoveDetails",
+  async (pokemon: Pokemon, { rejectWithValue }) => {
+    try {
+      if (!pokemon.moves.length) return rejectWithValue("No moves available");
+
+      const randomMove = pokemon.moves[Math.floor(Math.random() * pokemon.moves.length)].move.name;
+      const moveDetails = await getMoveDetails(randomMove);
+
+      if (!moveDetails) return rejectWithValue("Move details not found");
+
+      return { pokemonName: pokemon.name, move: moveDetails };
+    } catch (error) {
+      return rejectWithValue("Failed to fetch move details");
+    }
+  }
+);
+
+const battleSlice = createSlice({
+  name: "battle",
+  initialState,
+  reducers: {
+    setPokemons: (state, action: PayloadAction<{ pokemon1: Pokemon; pokemon2: Pokemon }>) => {
+      state.pokemon1 = action.payload.pokemon1;
+      state.pokemon2 = action.payload.pokemon2;
+      state.battleLog = ""; // reset battle log when new pokemon are selected
+      state.selectedMoves = {}; //clear previous moves
+    },
+
+    startBattle: (state) => {
+      const move1 = state.pokemon1 ? state.selectedMoves[state.pokemon1.name] : undefined;
+      const move2 = state.pokemon2 ? state.selectedMoves[state.pokemon2.name] : undefined;
+
+      if (!move1 || !move2 || move1.power === undefined || move2.power === undefined) {
+        state.battleLog = "Error: Moves not available for one or both Pokémon.";
+        return;
+      }
+
+      const winner = move1.power > move2.power ? state.pokemon1 : move2.power > move1.power ? state.pokemon2 : undefined;
+      const loser = winner === state.pokemon1 ? state.pokemon2 : state.pokemon1;
+
+      if (winner && loser) {
+        state.battleLog = `${winner.name} lands a decisive blow with ${
+          winner === state.pokemon1 ? move1.move.name : move2.move.name
+        }, knocking out ${loser.name}!`;
+      } else {
+        state.battleLog = `Draw! Both Pokemon used equal power.`;
+      }
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchMoveDetails.fulfilled, (state, action) => {
+      state.selectedMoves[action.payload.pokemonName] = action.payload.move;
+    });
+
+    builder.addCase(fetchMoveDetails.rejected, (_, action) => {
+      console.error("Move fetch error:", action.payload);
+    });
+  },
+});
+
+export const { setPokemons, startBattle } = battleSlice.actions;
+export default battleSlice.reducer;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,12 +1,14 @@
 import { configureStore } from "@reduxjs/toolkit";
 import pokemonReducer from "./pokemonSlice";
+import battleReducer from "./battleSlice";
 
 //redux store configuration
 export const store = configureStore({
   reducer: {
     pokemon: pokemonReducer,
+    battle: battleReducer,
   },
-  devTools: process.env.NODE_ENV !== "production", 
+  devTools: process.env.NODE_ENV !== "production",
 });
 
 //type definitions

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,18 +1,18 @@
 export interface PokemonMove {
-    move: {
-      name: string;
-    };
-  }
-  
-  export interface Pokemon {
-    id: number;
+  move: {
     name: string;
-    sprites: {
-      front_default: string;
-      back_default: string;
-    };
-    stats: { base_stat: number }[]; 
-    types: { type: { name: string } }[]; 
-    moves: PokemonMove[]; 
-  }
-  
+  };
+  power?: number;
+}
+
+export interface Pokemon {
+  id: number;
+  name: string;
+  sprites: {
+    front_default: string;
+    back_default: string;
+  };
+  stats: { base_stat: number }[];
+  types: { type: { name: string } }[];
+  moves: PokemonMove[];
+}


### PR DESCRIPTION
- Up on selecting pokemon players, integrating move api (https://pokeapi.co/api/v2/move/{move_name}) and navigated to battle view page.
- Battle view page displays pokemon 1 and 2 which are picked from pokemon api in home screen from the store. 
- based on the power when start battle button is clicked, the status is displayed in battle log. 
- Implemented Redux slice for managing Pokémon battles in BattleSlice
  - Added `setPokemons` reducer to initialize battle
  - Added `startBattle` reducer to determine battle outcome
  - Integrated `fetchMoveDetails` async thunk for fetching Pokémon moves
  - Updated `battleLog` state for tracking battle events
  - Handled move selection and error scenarios 
